### PR TITLE
CHANGED: preview/nextSideview shortcut changed to ctrl+shift+arrow

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,7 +21,7 @@ import { shouldCatchEvent, isEditable } from "../utils/dom";
 import { WithMenuAccelerators, Accelerators, Accelerator, sendFakeCombo } from "./WithMenuAccelerators";
 import { remote } from 'electron';
 import classnames from 'classnames';
-import { isPackage, isWin } from '../utils/platform';
+import { isPackage, isWin, isMac } from '../utils/platform';
 import { TabDescriptor } from "./TabList";
 import { getLocalizedError } from "../locale/error";
 
@@ -336,13 +336,13 @@ class App extends React.Component<WithNamespaces, IState> {
             />
             <Hotkey
                 global={true}
-                combo="ctrl + alt + right"
+                combo="ctrl + shift + right"
                 label={t('SHORTCUT.MAIN.NEXT_VIEW')}
                 onKeyDown={this.onNextView}
             />
             <Hotkey
                 global={true}
-                combo="ctrl + alt + left"
+                combo="ctrl + shift + left"
                 label={t('SHORTCUT.MAIN.PREVIOUS_VIEW')}
                 onKeyDown={this.onNextView}
             />
@@ -353,12 +353,30 @@ class App extends React.Component<WithNamespaces, IState> {
                 preventDefault={true}
                 onKeyDown={this.onReloadFileView}
             /> */}
-            <Hotkey
+            {isMac && (<Hotkey
+                global={true}
+                combo="mod + left"
+                label={t('SHORTCUT.ACTIVE_VIEW.BACKWARD_HISTORY')}
+                onKeyDown={this.backwardHistory}
+            />)}
+            {!isMac && (<Hotkey
                 global={true}
                 combo="alt + left"
                 label={t('SHORTCUT.ACTIVE_VIEW.BACKWARD_HISTORY')}
                 onKeyDown={this.backwardHistory}
-            />
+            />)}
+            {isMac && (<Hotkey
+                global={true}
+                combo="mod + right"
+                label={t('SHORTCUT.ACTIVE_VIEW.FORWARD_HISTORY')}
+                onKeyDown={this.forwardHistory}
+            />)}
+            {!isMac && (<Hotkey
+                global={true}
+                combo="alt + right"
+                label={t('SHORTCUT.ACTIVE_VIEW.FORWARD_HISTORY')}
+                onKeyDown={this.forwardHistory}
+            />)}
             <Hotkey
                 global={true}
                 combo="alt + right"

--- a/src/components/dialogs/ShortcutsDialog.tsx
+++ b/src/components/dialogs/ShortcutsDialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Dialog, Classes, Button, KeyCombo } from "@blueprintjs/core";
 import { withNamespaces, WithNamespaces } from "react-i18next";
+import { isMac } from "../../utils/platform";
 
 interface IShortcutsProps extends WithNamespaces {
     isOpen: boolean;
@@ -23,8 +24,8 @@ class ShortcutsDialogClass extends React.Component<IShortcutsProps>{
                 { combo: "ctrl + alt + right", label: t('SHORTCUT.MAIN.NEXT_VIEW') },
                 { combo: "ctrl + alt + left", label: t('SHORTCUT.MAIN.PREVIOUS_VIEW') },
                 { combo: "mod + r", label: t('SHORTCUT.MAIN.RELOAD_VIEW') },
-                { combo: "alt + left", label: t('SHORTCUT.ACTIVE_VIEW.BACKWARD_HISTORY') },
-                { combo: "alt + right", label: t('SHORTCUT.ACTIVE_VIEW.FORWARD_HISTORY') },
+                { combo: isMac && "mod + left" || "alt + left", label: t('SHORTCUT.ACTIVE_VIEW.BACKWARD_HISTORY') },
+                { combo: isMac && "mod + right" || "alt + right", label: t('SHORTCUT.ACTIVE_VIEW.FORWARD_HISTORY') },
                 { combo: "escape", label: t('SHORTCUT.LOG.TOGGLE') },
                 { combo: "mod + s", label: t('SHORTCUT.MAIN.KEYBOARD_SHORTCUTS') },
                 { combo: "mod + ,", label: t('SHORTCUT.MAIN.PREFERENCES') },
@@ -33,6 +34,8 @@ class ShortcutsDialogClass extends React.Component<IShortcutsProps>{
             ],
             // group: t('SHORTCUT.GROUP.ACTIVE_VIEW')
             [
+                { combo: isMac && "mod + left" || "alt + left", label: t('SHORTCUT.ACTIVE_VIEW.BACKWARD_HISTORY') },
+                { combo: isMac && "mod + right" || "alt + left", label: t('SHORTCUT.ACTIVE_VIEW.FORWARD_HISTORY') },
                 { combo: "meta + c", label: t('SHORTCUT.ACTIVE_VIEW.COPY') },
                 { combo: "meta + v", label: t('SHORTCUT.ACTIVE_VIEW.PASTE') },
                 { combo: "mod + shift + c", label: t('SHORTCUT.ACTIVE_VIEW.COPY_PATH') },

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -99,9 +99,13 @@ export class FileState {
             newCurrent = length - 1;
         }
 
+        if (newCurrent === this.current) {
+            return;
+        }
+
         this.current = newCurrent;
 
-        const path = history[current + dir];
+        const path = history[newCurrent];
 
         return this.cd(path, '', true, true)
             .catch(() => {


### PR DESCRIPTION
CHANGED: navHistory shortcut changed to mod+arrow (Mac) and alt+arrow(Linux, Win), like in browsers
FIXED: crash when calling navHistory shortcuts and history is empty
ADDED: navHistory shortcuts in shortcuts dialog