### PR TITLE
FIXED: postinstall script didn't work

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
-    "strict": true,
     "sourceMap": true,
     "module": "commonjs",
     "target": "es5",
     "lib": [
       "dom",
-      "es6"
+      "es2017"
     ],
     "jsx": "react",
     "experimentalDecorators": true

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
         "dist": "webpack --config webpack.config.production.js && electron-builder -mwl",
         "dist-win": "webpack --config webpack.config.production.js && electron-builder -w",
         "dist-mac": "webpack --config webpack.config.production.js && electron-builder -m",
-        "dist-linux": "webpack --config webpack.config.production.js && electron-builder -l"
+        "dist-linux": "webpack --config webpack.config.production.js && electron-builder -l",
+        "postinstall": "electron-builder install-app-deps"
     },
     "husky": {
         "hooks": {
             "pre-push": "npm run test:all"
         }
     },
-    "postinstall": "electron-builder install-app-deps",
     "author": {
         "name": "Nicolas Ramz",
         "email": "nicolas.ramz@gmail.com",


### PR DESCRIPTION
`postinstall` should be defined in scripts, not at the root of `package.json`.

Should fix native modules installation.