### PR TITLE
chore: update ftp-srv to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "electron-devtools-installer": "^2.2.4",
         "file-loader": "^2.0.0",
         "fork-ts-checker-webpack-plugin": "^4.1.3",
-        "ftp-srv": "^3.1.1",
+        "ftp-srv": "^3.1.2",
         "hoist-non-react-statics": "^3.3.0",
         "html-webpack-plugin": "^3.2.0",
         "husky": "^3.0.9",


### PR DESCRIPTION
We've just fixed a critical security vulnerability in `ftp-srv`, and though your dependencies are not pinned, I thought I would bring this into your view directly.

https://github.com/autovance/ftp-srv/security/advisories/GHSA-jw37-5gqr-cf9j