### PR TITLE
IMPROVED: detect dark mode in Linux/Windows as well fixes #188

### DIFF
--- a/e2e/cypress/mocks/electron.js
+++ b/e2e/cypress/mocks/electron.js
@@ -45,6 +45,9 @@ module.exports = {
         // new in 7.0
         nativeTheme: {
             shouldUseDarkColors: false,
+            on: () => {
+                //
+            }
         },
     },
 };

--- a/src/state/settingsState.ts
+++ b/src/state/settingsState.ts
@@ -49,12 +49,7 @@ export class SettingsState {
     }
 
     installListeners(): void {
-        // systemPreferences may not be defined if running outside of Electron
-        if (isMojave && systemPreferences) {
-            systemPreferences.subscribeNotification('AppleInterfaceThemeChangedNotification', () =>
-                this.setActiveTheme(),
-            );
-        }
+        remote.nativeTheme.on('updated', () => console.log('updated') || this.setActiveTheme());
     }
 
     getParam(name: string): JSObject {
@@ -160,7 +155,7 @@ export class SettingsState {
         if (this.darkMode === 'auto') {
             // CHECKME!
             // this.isDarkModeActive = isMojave && systemPreferences ? systemPreferences.isDarkMode() : false;
-            this.isDarkModeActive = isMojave && remote.nativeTheme.shouldUseDarkColors;
+            this.isDarkModeActive = remote.nativeTheme.shouldUseDarkColors;
         } else {
             this.isDarkModeActive = this.darkMode;
         }


### PR DESCRIPTION
Use the new nativeTheme module and don't rely on systemPreferences anymore. Also enables darkMode support for Windows & Linux.