### PR TITLE
ADDED: feedback if terminal could not be started fixes #186

### DIFF
--- a/src/components/FileTable.tsx
+++ b/src/components/FileTable.tsx
@@ -177,11 +177,11 @@ export class FileTableClass extends React.Component<Props, State> {
     public componentDidUpdate(): void {
         const scrollTop = this.state.position === -1 ? this.cache.scrollTop : null;
         const viewState = this.injected.viewState;
-        if (!viewState.viewId) {
-            console.log('componentDidUpdate', this.state.position, this.cache.scrollTop, scrollTop);
-        }
+        // if (!viewState.viewId) {
+        //     console.log('componentDidUpdate', this.state.position, this.cache.scrollTop, scrollTop);
+        // }
 
-        // edge case: previous saved scrollTop isn't good anymore
+        // edge case: previous saved scrollTop isn't valid anymore
         // eg. files have been deleted, or selected item has been renamed,
         // so that using previous scrollTop would hide the selected item
         // if (/*scrollTop !== null && scrollTop > -1*/1) {

--- a/src/components/dialogs/PrefsDialog.tsx
+++ b/src/components/dialogs/PrefsDialog.tsx
@@ -6,6 +6,7 @@ import { SettingsState } from '../../state/settingsState';
 import { inject } from 'mobx-react';
 import { Select, ItemRenderer } from '@blueprintjs/select';
 import { FsLocal, FolderExists } from '../../services/plugins/FsLocal';
+import { AppAlert } from '../AppAlert';
 import { ipcRenderer } from 'electron';
 import { HOME_DIR } from '../../utils/platform';
 
@@ -186,10 +187,17 @@ class PrefsDialogClass extends React.Component<PrefsProps, State> {
         settingsState.saveSettings();
     };
 
-    testTerminal = (): void => {
-        const { settingsState } = this.injected;
+    testTerminal = async (): Promise<void> => {
+        const { settingsState, t } = this.injected;
         const path = settingsState.getTerminalCommand(HOME_DIR);
-        ipcRenderer.invoke('openTerminal', path);
+        const error: { code: number; terminal: string } = await ipcRenderer.invoke('openTerminal', path);
+        if (error) {
+            const { code, terminal } = error;
+            AppAlert.show(t('DIALOG.PREFS.TEST_TERMINAL_FAILED', { terminal, code }), {
+                intent: Intent.DANGER,
+                icon: 'error',
+            });
+        }
     };
 
     public render(): React.ReactNode {

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -176,11 +176,22 @@ const ElectronApp = {
             this.openDevTools(true);
         });
 
-        ipcMain.handle('openTerminal', (event: Event, cmd: string) => {
-            console.log('running', cmd);
-            const exec = child_process.exec;
-            exec(cmd).unref();
-        });
+        ipcMain.handle(
+            'openTerminal',
+            (event: Event, cmd: string): Promise<{ code: number; terminal: string }> => {
+                console.log('running', cmd);
+                const exec = child_process.exec;
+                return new Promise((resolve) => {
+                    exec(cmd, (error: child_process.ExecException) => {
+                        if (error) {
+                            resolve({ code: error.code, terminal: cmd });
+                        } else {
+                            resolve();
+                        }
+                    }).unref();
+                });
+            },
+        );
 
         ipcMain.handle('languageChanged', (e: Event, strings: LocaleString) => {
             if (this.appMenu) {

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -70,7 +70,8 @@
                 "INVALID_FOLDER": "Invalid folder name or non-existing folder",
                 "DEFAULT_TERMINAL": "External terminal",
                 "DEFAULT_TERMINAL_HELP": "Customizes what kind of terminal to launch",
-                "TEST_TERMINAL": "Click here to launch the specified external terminal"
+                "TEST_TERMINAL": "Click here to launch the specified external terminal",
+                "TEST_TERMINAL_FAILED": "Unable to start specified terminal: {{terminal}} (return code: {{code}})"
             },
             "DELETE": {
                 "CONFIRM": "Are you sure you want to delete <1>{{count}}</1> file(s)/folder(s)?<3 /><4 />This action will <6>permanentaly</6> delete the selected elements."
@@ -199,7 +200,8 @@
             "NODEST": "copy target could not be accessed",
             "COPY_ERROR": "Couldn't copy files: {{message}}",
             "COPY_UNKNOWN_ERROR": "Error while copying files.",
-            "SHELL_OPEN_FAILED": "Could not open file: {{path}}"
+            "SHELL_OPEN_FAILED": "Could not open file: {{path}}",
+            "OPEN_TERMINAL_FAILED": "Could not open terminal. Check that the path is correct in the settings."
         },
         "MAIN_PROCESS": {
             "PRESS_TO_EXIT": "Keep pressing ⌘Q to exit"

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -70,7 +70,8 @@
                 "INVALID_FOLDER": "Nom de dossier invalide ou introuvable",
                 "DEFAULT_TERMINAL": "Terminal externe",
                 "DEFAULT_TERMINAL_HELP": "Spécifie le type de terminal à lancer",
-                "TEST_TERMINAL": "Cliquez ici pour lancer le terminal specifié"
+                "TEST_TERMINAL": "Cliquez ici pour lancer le terminal specifié",
+                "TEST_TERMINAL_FAILED": "Impossible de lancer le terminal spécifié: {{terminal}} (code de retour: {{code}})"
             },
             "DELETE": {
                 "CONFIRM": "Etes-vous sûr de vouloir supprimer <1>{{count}}</1> fichier(s)/dossier(s) ?<3 /><4 />Cette action supprimera de manière <6>permanente</6> les éléments sélectionnés."
@@ -199,7 +200,8 @@
             "NODEST": "la destination de la copie n'est pas accessible",
             "COPY_ERROR": "La copie n'a pu s'effectuer: {{message}}",
             "COPY_UNKNOWN_ERROR": "Impossible de copier les fichiers demandés.",
-            "SHELL_OPEN_FAILED": "Impossible d'ouvrir le fichier: {{path}}"
+            "SHELL_OPEN_FAILED": "Impossible d'ouvrir le fichier: {{path}}",
+            "OPEN_TERMINAL_FAILED": "Impossible d'ouvrir le terminal. Vérifiez le chemin du terminal dans les paramètres."
         },
         "MAIN_PROCESS": {
             "PRESS_TO_EXIT": "Maintenez la touche ⌘Q enfoncée pour quitter"

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -559,9 +559,10 @@ export class FileState {
         return this.cd(file.dir, file.fullname).catch(this.handleError);
     }
 
-    openTerminal(path: string): void {
+    async openTerminal(path: string): Promise<boolean> {
         if (this.getFS().name === 'local') {
-            ipcRenderer.invoke('openTerminal', path);
+            const error: { code: number } = await ipcRenderer.invoke('openTerminal', path);
+            return !!error;
         }
     }
 

--- a/src/state/settingsState.ts
+++ b/src/state/settingsState.ts
@@ -49,7 +49,7 @@ export class SettingsState {
     }
 
     installListeners(): void {
-        remote.nativeTheme.on('updated', () => console.log('updated') || this.setActiveTheme());
+        remote.nativeTheme.on('updated', () => this.setActiveTheme());
     }
 
     getParam(name: string): JSObject {


### PR DESCRIPTION
- show an alert if testing the terminal doesn't work (preferences dialog)
- show a warning toast if terminal could not be opened in active directory
- do not attempt to open a terminal if directory could not be displayed
- fixes #186, regression introduced when upgrading to Electron 9