### PR TITLE
FIXED: call to wsl exe

### DIFF
--- a/src/utils/wsl.ts
+++ b/src/utils/wsl.ts
@@ -1,12 +1,14 @@
 import { isWin } from './platform';
 import { exec } from 'child_process';
 
+const WSL_EXE = 'wsl.exe';
+
 export const hasWSL = (): Promise<boolean> => {
     return new Promise((resolve) => {
         if (!isWin) {
             resolve(false);
         } else {
-            exec('wsl -l', (error, stdout, stderr) => {
+            exec(`${WSL_EXE} -l`, (error, stdout, stderr) => {
                 if (!error && !stderr) {
                     resolve(true);
                 } else {
@@ -19,10 +21,10 @@ export const hasWSL = (): Promise<boolean> => {
 
 export const getWSLDistributions = (): Promise<string[]> => {
     return new Promise((resolve, reject) => {
-        exec('wsl -l -q', (error, stdout, stderr) => {
+        exec(`${WSL_EXE} -l -q`, (error, stdout, stderr) => {
             if (!error && !stderr && stdout) {
                 const trimmed = stdout.replace(/\0/g, '');
-                resolve(trimmed.split('\r\n').filter(str => str.length))
+                resolve(trimmed.split('\r\n').filter((str) => str.length));
             } else {
                 resolve([]);
             }
@@ -40,9 +42,9 @@ export const decodeWSLFilename = (str: string) => {
             '': '\\',
             '': '|',
             '': '?',
-            '': '*'
+            '': '*',
         } as { [key: string]: string })[m];
     });
-}
+};
 
 export const WSL_PREFIX = '\\\\wsl$\\';


### PR DESCRIPTION
Fixes WSL not working in local if there is a `wsl.js` file in the root directory: this would have been called instead of the Windows `wsl.exe` command line tool.