### PR TITLE
Copy to clipboard Toast: don't show when no files selected.

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -269,15 +269,16 @@ const App = inject('settingsState')(
                     const { t } = this.injected
                     const num = this.appState.setClipboard(fileCache)
 
-                    AppToaster.show(
-                        {
-                            message: t('COMMON.CP_COPIED', { count: num }),
-                            icon: 'tick',
-                            intent: Intent.NONE,
-                        },
-                        undefined,
-                        true,
-                    )
+                    num &&
+                        AppToaster.show(
+                            {
+                                message: t('COMMON.CP_COPIED', { count: num }),
+                                icon: 'tick',
+                                intent: Intent.NONE,
+                            },
+                            undefined,
+                            true,
+                        )
                 }
             }
 

--- a/src/components/Statusbar.tsx
+++ b/src/components/Statusbar.tsx
@@ -33,11 +33,12 @@ export const StatusbarClass = inject(
 
                 const num = appState.setClipboard(viewState.getVisibleCache())
 
-                AppToaster.show({
-                    message: t('COMMON.CP_COPIED', { count: num }),
-                    icon: 'tick',
-                    intent: Intent.NONE,
-                })
+                num &&
+                    AppToaster.show({
+                        message: t('COMMON.CP_COPIED', { count: num }),
+                        icon: 'tick',
+                        intent: Intent.NONE,
+                    })
             }
 
             // shouldComponentUpdate() {


### PR DESCRIPTION
We were showing a toast "0 files copied to the clipboard" when no files where selected and copy shortcurt was selected.

This is of course useless.