### PR TITLE
localizedError: add EROS (readonly device) handling

### DIFF
--- a/src/locale/error.ts
+++ b/src/locale/error.ts
@@ -12,6 +12,8 @@ export interface IOError {
 }
 
 export function getLocalizedError(error: string | IOError): LocalizedError {
+    const supportedErrors =
+        /ENOTFOUND|ECONNREFUSED|ENOENT|EPERM|EACCES|EIO|ENOSPC|EEXIST|EHOSTDOWN|ENOTDIR|NODEST|530|550|EROS/
     const niceError: LocalizedError = {}
     const {
         i18next: { t },
@@ -33,69 +35,19 @@ export function getLocalizedError(error: string | IOError): LocalizedError {
         niceError.code = (error as IOError).code
     }
 
-    switch (niceError.code) {
-        case 'ENOTFOUND':
-            niceError.message = t('ERRORS.ENOTFOUND')
+    switch (supportedErrors.test(niceError.code.toString())) {
+        case true:
+            niceError.message = t(`ERRORS.${niceError.code.toString()}`)
             break
 
-        case 'ECONNREFUSED':
-            niceError.message = t('ERRORS.ECONNREFUSED')
-            break
-
-        case 'ENOENT':
-            niceError.message = t('ERRORS.ENOENT')
-            break
-
-        case 'EPERM':
-            niceError.message = t('ERRORS.EPERM')
-            break
-
-        case 'EACCES':
-            niceError.message = t('ERRORS.EACCES')
-            break
-
-        case 'EIO':
-            niceError.message = t('ERRORS.EIO')
-            break
-
-        case 'ENOSPC':
-            niceError.message = t('ERRORS.ENOSPC')
-            break
-
-        case 'EEXIST':
-            niceError.message = t('ERRORS.EEXIST')
-            break
-
-        case 'BAD_FILENAME':
-            const acceptedChars = isWin ? t('ERRORS.WIN_VALID_FILENAME') : t('ERRORS.UNIX_VALID_FILENAME')
-
-            niceError.message = t('ERRORS.BAD_FILENAME', { entry: (error as IOError).newName }) + '. ' + acceptedChars
-            break
-
-        case 'EHOSTDOWN':
-            niceError.message = t('ERRORS.EHOSTDOWN')
-            break
-
-        case 'ENOTDIR':
-            niceError.message = t('ERRORS.ENOTDIR')
-            break
-
-        case 'NODEST':
-            niceError.message = t('ERRORS.NODEST')
-            break
-
-        case 530:
-            niceError.message = t('ERRORS.530')
-            break
-
-        case 550:
-            niceError.message = t('ERRORS.550')
-            break
-
-        default:
-            debugger
-            niceError.message = t('ERRORS.UNKNOWN')
-            break
+        case false:
+            if (niceError.code === 'BAD_FILENAME') {
+                const acceptedChars = isWin ? t('ERRORS.WIN_VALID_FILENAME') : t('ERRORS.UNIX_VALID_FILENAME')
+                niceError.message =
+                    t('ERRORS.BAD_FILENAME', { entry: (error as IOError).newName }) + '. ' + acceptedChars
+            } else {
+                niceError.message = t('ERRORS.UNKNOWN')
+            }
     }
 
     return niceError

--- a/src/locale/lang/en.json
+++ b/src/locale/lang/en.json
@@ -188,6 +188,7 @@
             "530": "Login authentication failed",
             "550": "File unavailable, not found, not accessible",
             "ENOTDIR": "Path entered is not a directory",
+            "EROS": "Device is read only.",
             "UNKNOWN": "An error has occured",
             "GENERIC": "{{error.message}} (code {{error.code}})",
             "BAD_FILENAME": "File or directory name not valid: '{{entry}}'",

--- a/src/locale/lang/fr.json
+++ b/src/locale/lang/fr.json
@@ -188,6 +188,7 @@
             "530": "Echec de l'authentification",
             "550": "Fichier non disponible, introuvable ou non accessible.",
             "ENOTDIR": "Le chemin entré ne pointe pas vers un dossier",
+            "EROS": "Le périphérique n'autorise pas l'écriture.",
             "UNKNOWN": "Une erreur est survenue",
             "GENERIC": "{{error.message}} (code {{error.code}})",
             "BAD_FILENAME": "Nom de fichier ou dossier non valide: '{{entry}}'",


### PR DESCRIPTION
Also refactored getLocalizedError using a regex instead of a dozen cases
with the same code: should make it a lot easier to update.

Fixes #275 