### PR TITLE
FsLocal.access: use async fs.access instead of incorrect fs.statSync

### DIFF
--- a/src/services/plugins/FsLocal.ts
+++ b/src/services/plugins/FsLocal.ts
@@ -191,7 +191,7 @@ export class LocalApi implements FsApi {
 
     async exists(path: string, transferId = -1): Promise<boolean> {
         try {
-            fs.statSync(path)
+            await fs.promises.access(path)
             return true
         } catch (err) {
             if (err.code === 'ENOENT') {


### PR DESCRIPTION
There is no need to call fs.stat to check the existence of a file/dir, especially not a sync version.

Use async version of `fs.access` instead.

Note that there are other calls that should be fixed too.