### PR TITLE
Shortcuts dialog add tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
     moduleDirectories: [
       'node_modules',
        'src/utils/test',
+       'src',
       __dirname,
    ],    
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "@swc/core": "^1.3.10",
                 "@testing-library/jest-dom": "^5.16.5",
                 "@testing-library/react": "^12.1.5",
+                "@testing-library/user-event": "^14.4.3",
                 "@types/copy-webpack-plugin": "^6.0.0",
                 "@types/hoist-non-react-statics": "^3.3.1",
                 "@types/html-webpack-plugin": "^3.2.4",
@@ -2288,6 +2289,19 @@
             "peerDependencies": {
                 "react": "<18.0.0",
                 "react-dom": "<18.0.0"
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.4.3",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+            "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -17343,6 +17357,13 @@
                 "@testing-library/dom": "^8.0.0",
                 "@types/react-dom": "<18.0.0"
             }
+        },
+        "@testing-library/user-event": {
+            "version": "14.4.3",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+            "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+            "dev": true,
+            "requires": {}
         },
         "@tootallnate/once": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
         "@swc/core": "^1.3.10",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
+        "@testing-library/user-event": "^14.4.3",
         "@types/copy-webpack-plugin": "^6.0.0",
         "@types/hoist-non-react-statics": "^3.3.1",
         "@types/html-webpack-plugin": "^3.2.4",

--- a/src/components/dialogs/ShortcutsDialog.tsx
+++ b/src/components/dialogs/ShortcutsDialog.tsx
@@ -10,7 +10,7 @@ interface ShortcutsProps {
     onClose: () => void
 }
 
-const buildShortcuts = (t: TFunction<'translation', undefined>) => [
+export const buildShortcuts = (t: TFunction<'translation', undefined>) => [
     // group: t('SHORTCUT.GROUP.GLOBAL'),
     [
         { combo: 'alt + mod + l', label: t('SHORTCUT.MAIN.DOWNLOADS_TAB') },

--- a/src/components/dialogs/__tests__/shortcutsDialog.test.tsx
+++ b/src/components/dialogs/__tests__/shortcutsDialog.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { ShortcutsDialog } from '../ShortcutsDialog'
+import { render, screen, LOCALE_EN, userEvent } from 'rtl'
+
+describe('ShortcutsDialog', () => {
+    const DEFAULT_PROPS = {
+        isOpen: true,
+        onClose: jest.fn(),
+    }
+
+    const exitLabel = LOCALE_EN.SHORTCUT.MAIN.QUIT
+    const reloadViewLabel = LOCALE_EN.SHORTCUT.MAIN.RELOAD_VIEW
+    const placeholder = LOCALE_EN.DIALOG.SHORTCUTS.FILTER_PLACEHOLDER
+
+    beforeEach(() => jest.resetAllMocks())
+
+    describe('shortcuts list', () => {
+        it('should render shortcuts', () => {
+            render(<ShortcutsDialog {...DEFAULT_PROPS} />)
+            expect(screen.getByText(exitLabel)).toBeInTheDocument()
+            expect(screen.getByText(reloadViewLabel)).toBeInTheDocument()
+        })
+
+        it('should call onClose', async () => {
+            const user = userEvent.setup()
+            render(<ShortcutsDialog {...DEFAULT_PROPS} />)
+            await user.click(screen.getByText(LOCALE_EN.COMMON.CLOSE))
+            expect(DEFAULT_PROPS.onClose).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('filter', () => {
+        it('should render filter', () => {
+            render(<ShortcutsDialog {...DEFAULT_PROPS} />)
+            expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument()
+        })
+
+        it('should apply filter', async () => {
+            const user = userEvent.setup()
+            render(<ShortcutsDialog {...DEFAULT_PROPS} />)
+            screen.getByPlaceholderText(placeholder).focus()
+            await user.paste(exitLabel.substring(0, 5))
+
+            expect(screen.getByText(exitLabel)).toBeInTheDocument()
+            expect(screen.queryByText(reloadViewLabel)).not.toBeInTheDocument()
+        })
+
+        it('should show empty message if filter does not return any results', async () => {
+            const user = userEvent.setup()
+            render(<ShortcutsDialog {...DEFAULT_PROPS} />)
+            screen.getByPlaceholderText(placeholder).focus()
+            await user.paste('foo_bar')
+
+            expect(screen.getByText(LOCALE_EN.DIALOG.SHORTCUTS.NO_RESULTS)).toBeInTheDocument()
+        })
+    })
+})

--- a/src/hooks/__tests__/useStores.test.tsx
+++ b/src/hooks/__tests__/useStores.test.tsx
@@ -2,22 +2,22 @@
  * @jest-environment jsdom
  */
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import { useStores } from '../useStores'
-import { renderWithProvider } from 'rtl'
+import { render } from 'rtl'
 
-const Component = () => {
-    const { settingsState } = useStores('settingsState')
+const Component = ({ storeName }: { storeName: string }) => {
+    const { settingsState } = useStores(storeName)
     return <div>{settingsState.lang}</div>
 }
 
 describe('useStores', () => {
     it('should return mobx store', () => {
-        renderWithProvider(<Component />)
+        render(<Component storeName="settingsState" />)
         expect(screen.getByText('fr')).toBeInTheDocument()
     })
 
     it('should throw if store could not be found', () => {
-        expect(() => render(<Component />)).toThrow("No MboXProvider for 'settingsState'!")
+        expect(() => render(<Component storeName="unknown" />)).toThrow("No MboXProvider for 'unknown'!")
     })
 })

--- a/src/utils/test/i18n.ts
+++ b/src/utils/test/i18n.ts
@@ -1,0 +1,29 @@
+import i18next from 'i18next'
+import en from 'locale/lang/en.json'
+
+const i18n = {
+    promise: i18next.init({
+        lng: 'en',
+        // we init with resources
+        resources: {
+            en,
+        },
+        fallbackLng: 'en',
+
+        // have a common namespace used around the full app
+        ns: ['translations'],
+        defaultNS: 'translations',
+
+        interpolation: {
+            escapeValue: false, // not needed for react!!
+            formatSeparator: ',',
+        },
+        react: {
+            // wait: true,
+            useSuspense: false,
+        },
+    }),
+    i18next,
+}
+
+export { i18n }

--- a/src/utils/test/rtl.tsx
+++ b/src/utils/test/rtl.tsx
@@ -1,38 +1,50 @@
 import React from 'react'
+import type { ReactElement } from 'react'
 import { render } from '@testing-library/react'
 import { makeAutoObservable } from 'mobx'
 import { Provider } from 'mobx-react'
+import { DndProvider } from 'react-dnd'
+import { HTML5Backend } from 'react-dnd-html5-backend'
+import { i18n } from './i18n'
+import { I18nextProvider } from 'react-i18next'
+import { HotkeysProvider } from '@blueprintjs/core'
+import userEvent from '@testing-library/user-event'
+import en from 'locale/lang/en.json'
+
+const LOCALE_EN = en.translations
 
 class State {
     lang = 'fr'
     darkMode = false
+    splitView = false
 
     constructor() {
         makeAutoObservable(this)
     }
 }
 
-const renderWithProvider = (jsx: React.ReactElement) => {
+const renderWithProviders = (jsx: React.ReactElement, options = {}) => {
     const settingsState = new State()
     return render(<Provider settingsState={settingsState}>{jsx}</Provider>)
 }
 
-// TODO: provide all needed providers for react-explorer
-// const AllTheProviders = ({children}) => {
-//   return (
-//     <ThemeProvider theme="light">
-//       <TranslationProvider messages={defaultStrings}>
-//         {children}
-//       </TranslationProvider>
-//     </ThemeProvider>
-//   )
-// }
+const AllTheProviders = ({ children }: { children: ReactElement }) => {
+    const settingsState = new State()
+    return (
+        <DndProvider backend={HTML5Backend}>
+            <Provider settingsState={settingsState}>
+                <I18nextProvider i18n={i18n.i18next}>
+                    <HotkeysProvider>{children}</HotkeysProvider>
+                </I18nextProvider>
+            </Provider>
+        </DndProvider>
+    )
+}
 
-// const customRender = (ui, options) =>
-//   render(ui, {wrapper: AllTheProviders, ...options})
+const customRender = (ui: ReactElement, options = {}) => render(ui, { wrapper: AllTheProviders, ...options })
 
 // re-export everything
 export * from '@testing-library/react'
 
 // override render method
-export { renderWithProvider }
+export { customRender as render, LOCALE_EN, userEvent }


### PR DESCRIPTION
Added RTL tests for the `ShortcutsDialog` component.

The shortcutsList  was also turned into a record and we now iterate through each keys:
this will allow to add more sections without having to add JSX code. 

Also:
    - added userEvent
    - added new custom render method that wraps all needed providers
    - export userEvent, LOCALE_EN from rtl special import