### PR TITLE
Toolbar/pathbar: fix overflow when window is very small

### DIFF
--- a/src/css/favoritesPanel.css
+++ b/src/css/favoritesPanel.css
@@ -15,8 +15,7 @@
 }
 
 .favoritesPanel .bp4-tree-node-content-0 {
-    color:#5c7080;
-    pointer-events:none;
+    pointer-events: none;
 }
 
 .favoritesPanel .bp4-tree-node-content-0:hover {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -32,6 +32,7 @@ button.small:hover{
  */
 .toolbar > .bp4-popover2-target {
     flex-grow: 1;
+    flex-shrink: 1;
 }
 
 /* auto resize layout */


### PR DESCRIPTION
Also restored default color on left panel titles: contrast was too small.

Fixes #296 