### PR TITLE
build: copy drivelist.node module to build dir

### DIFF
--- a/webpack.config.production.ts
+++ b/webpack.config.production.ts
@@ -154,6 +154,10 @@ export default [
                             from: 'img/icon-512x512.ico',
                             to: 'icon.ico',
                         },
+                        {
+                            from: 'node_modules/drivelist/build/Release/drivelist.node',
+                            to: 'drivelist.node',
+                        },
                     ],
                 }),
             ],

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -133,6 +133,10 @@ export default [
                             from: 'img/icon-512x512.png',
                             to: 'icon.png',
                         },
+                        {
+                            from: 'node_modules/drivelist/build/Release/drivelist.node',
+                            to: 'drivelist.node',
+                        },
                     ],
                 }),
             ],


### PR DESCRIPTION
This should be done automatically but for some reason it does not work.