### PR TITLE
appMenus: fixed reload accelerator

### DIFF
--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -142,12 +142,11 @@ const ElectronApp = {
     /**
      * Clears the session cache and reloads main window without cache
      */
-    reloadApp(): void {
+    async reloadApp(): Promise<void> {
         const mainWindow = this.mainWindow
         if (mainWindow) {
-            mainWindow.webContents.session.clearCache(() => {
-                mainWindow.webContents.reloadIgnoringCache()
-            })
+            await mainWindow.webContents.session.clearCache()
+            mainWindow.webContents.reloadIgnoringCache()
         }
     },
     /**


### PR DESCRIPTION
session.clear API have been updated and now returns a promise instead of having a callback parameter.

This fixes the reload menu/shortcut not working.