### PR TITLE
build: exclude electron-devtools-installer from source-map-loader

### DIFF
--- a/e2e/webpack.config.e2e.ts
+++ b/e2e/webpack.config.e2e.ts
@@ -93,7 +93,7 @@ const baseConfig = {
             },
 
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: /electron-devtools-installer/ },
             // css loader
             {
                 test: /\.css$/,

--- a/webpack.config.production.ts
+++ b/webpack.config.production.ts
@@ -63,7 +63,7 @@ const baseConfig: webpack.Configuration = {
             },
 
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: /electron-devtools-installer/ },
             // css loader
             {
                 test: /\.css$/,

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -51,7 +51,7 @@ const baseConfig: webpack.Configuration = {
             },
 
             // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+            { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader', exclude: /electron-devtools-installer/ },
             // css loader
             {
                 test: /\.css$/,


### PR DESCRIPTION
This will fix the 3 warnings displayed when building react-explorer.