### PR TITLE
appState: add toogleSplitViewMode that adds a fileCache if empty

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -39,9 +39,9 @@ const Nav = observer(() => {
     }
 
     const onToggleSplitView = (): void => {
+        debugger
         if (appState.isExplorer) {
-            const winState = appState.winStates[0]
-            winState.toggleSplitViewMode()
+            appState.toggleSplitViewMode()
         }
     }
 

--- a/src/components/shortcuts/MenuAccelerators.tsx
+++ b/src/components/shortcuts/MenuAccelerators.tsx
@@ -152,8 +152,7 @@ class MenuAcceleratorsClass extends React.Component<Props> {
 
     onToggleSplitView = (): void => {
         if (this.appState.isExplorer) {
-            const winState = this.appState.winStates[0]
-            winState.toggleSplitViewMode()
+            this.appState.toggleSplitViewMode()
         }
     }
 

--- a/src/state/appState.tsx
+++ b/src/state/appState.tsx
@@ -54,11 +54,6 @@ export class AppState {
         splitView: false,
     }
 
-    toggleSplitViewMode(): void {
-        const winState = this.winStates[0]
-        winState.toggleSplitViewMode()
-    }
-
     clipboard = new ClipboardState()
 
     transferListState = new TransferListState()
@@ -167,6 +162,16 @@ export class AppState {
                 dstFsName: destCache.getFS().name,
             }
             this.copy(options)
+        }
+    }
+
+    toggleSplitViewMode() {
+        const winState = this.winStates[0]
+        winState.toggleSplitViewMode()
+
+        const view = winState.getActiveView()
+        if (!view.getVisibleCache()) {
+            view.addCache(this.settingsState.defaultFolder, -1, true)
         }
     }
 

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -387,7 +387,9 @@ export class FileState {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     handleError = (error: any): Promise<void> => {
         console.log('handleError', error)
-        this.setStatus('ok')
+        // we want to show the error on first nav
+        // otherwise we keep previous
+        this.setStatus('ok', this.history.length === 0 || this.error)
         const niceError = getLocalizedError(error)
         console.log('orignalCode', error.code, 'newCode', niceError.code)
         AppAlert.show(i18n.i18next.t('ERRORS.GENERIC', { error }), {
@@ -446,7 +448,6 @@ export class FileState {
                 console.log('error cd/list for path', joint, 'error was', error)
                 this.setStatus('ok', true)
                 const localizedError = getLocalizedError(error)
-                //return Promise.reject(localizedError);
                 throw localizedError
             })
     }, this.waitForConnection)


### PR DESCRIPTION
There was no cache added when enabling splitviewMode. This crashed SideView which was expecting one.

This PR adds a new appState.toggleSplitViewMode method that toggles split view and adds a new cache using default path if needed.

Also fixed to display an error on first load if an error occured, instead of showing the empty placeholder.