### PR TITLE
FileState: attempt to fix error status when opening a non valid dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-explorer",
-    "version": "2.3.1",
+    "version": "3.0.0-beta.1",
     "description": "Plugin-based file explorer written with React",
     "main": "build/main.js",
     "build": {
@@ -36,9 +36,9 @@
         "server": "pm2 start \"npx ws -d ./build-e2e -p 8080\" --name cy-server",
         "server:stop": "pm2 --silent stop cy-server || true",
         "dist": "webpack --config webpack.config.production.ts && electron-builder -mwl",
-        "dist-win": "webpack --config webpack.config.production.ts && electron-builder -w",
-        "dist-mac": "webpack --config webpack.config.production.ts && electron-builder -m",
-        "dist-linux": "webpack --config webpack.config.production.ts && electron-builder -l",
+        "dist-win": "webpack --config webpack.config.production.ts && electron-builder -w --x64 --arm64",
+        "dist-mac": "webpack --config webpack.config.production.ts && electron-builder -m --universal",
+        "dist-linux": "webpack --config webpack.config.production.ts && electron-builder -l --x64 --arm64",
         "postinstall": "electron-builder install-app-deps && npm run install:e2e",
         "install:e2e": "cd e2e && npm install"
     },

--- a/src/state/fileState.ts
+++ b/src/state/fileState.ts
@@ -41,6 +41,7 @@ export class FileState {
     status: TStatus = 'ok'
 
     error = false
+    previousError = false
 
     cmd = ''
 
@@ -81,7 +82,16 @@ export class FileState {
 
     setStatus(status: TStatus, error = false): void {
         this.status = status
-        this.error = error
+        if (!error) {
+            this.previousError = this.error
+            this.error = false
+        } else {
+            if (this.history.length === 0 || this.previousError) {
+                this.error = true
+            }
+        }
+        // this.error = error
+        // this.history.length === 0 || this.error
     }
 
     addPathToHistory(path: string): void {
@@ -393,7 +403,7 @@ export class FileState {
         console.log('handleError', error)
         // we want to show the error on first nav
         // otherwise we keep previous
-        this.setStatus('ok', this.history.length === 0 || this.error)
+        this.setStatus('ok', true)
         const niceError = getLocalizedError(error)
         console.log('orignalCode', error.code, 'newCode', niceError.code)
         AppAlert.show(i18n.i18next.t('ERRORS.GENERIC', { error }), {


### PR DESCRIPTION
In this particular case, an error icon appeared in the toolbar icon:
- read a valid directory
- attempt to open an invalid dir

An alert would be displayed, but the file view would keep showing previous (valid) directory's files. While this is expected, the Tab Bar would incorrectly keep showing the error icon.

This has been fixed by keeping the previous error state: this way we can only show it if there was previously an error.