### PR TITLE
Fix double click should no enable inline edit

### DIFF
--- a/src/components/FileView.tsx
+++ b/src/components/FileView.tsx
@@ -16,7 +16,7 @@ import { useMenuAccelerator } from '$src/hooks/useAccelerator'
 import { TypeIcons } from '$src/constants/icons'
 
 import { ArrowKey, DraggedObject, FileViewItem } from '$src/types'
-import { HeaderMouseEvent, ItemMouseEvent, useLayout } from '$src/hooks/useLayout'
+import { HeaderMouseEvent, InlineEditEvent, ItemMouseEvent, useLayout } from '$src/hooks/useLayout'
 import { useStores } from '$src/hooks/useStores'
 import { useKeyDown } from '$src/hooks/useKeyDown'
 
@@ -149,26 +149,23 @@ const FileView = observer(({ hide }: Props) => {
         const file = item.nodeData
         const toggleMode = isMac ? event.metaKey : event.ctrlKey
 
-        // if (!event.shiftKey && !toggleMode && item.isSelected && (!editingId || !sameID(file.id, editingId))) {
-        //     cache.setEditingFile(file)
-        // } else {
         selectFile(file, toggleMode, event.shiftKey)
-        // }
     }
 
-    const onInlineEdit = ({ action, data }) => {
+    const onInlineEdit = ({ action, data }: InlineEditEvent) => {
         switch (action) {
             case 'validate':
-                appState.renameEditingFile(cache, data)
+                appState.renameEditingFile(cache, data as string)
                 break
 
             case 'start':
                 console.log('starting edit file')
-                const file = data.nodeData
+                const file = (data as FileViewItem).nodeData
                 cache.setEditingFile(file)
                 break
 
-                cancel: cache.setEditingFile(null)
+            case 'cancel':
+                cache.setEditingFile(null)
         }
     }
 

--- a/src/components/FileView.tsx
+++ b/src/components/FileView.tsx
@@ -149,10 +149,26 @@ const FileView = observer(({ hide }: Props) => {
         const file = item.nodeData
         const toggleMode = isMac ? event.metaKey : event.ctrlKey
 
-        if (!event.shiftKey && !toggleMode && item.isSelected && (!editingId || !sameID(file.id, editingId))) {
-            cache.setEditingFile(file)
-        } else {
-            selectFile(file, toggleMode, event.shiftKey)
+        // if (!event.shiftKey && !toggleMode && item.isSelected && (!editingId || !sameID(file.id, editingId))) {
+        //     cache.setEditingFile(file)
+        // } else {
+        selectFile(file, toggleMode, event.shiftKey)
+        // }
+    }
+
+    const onInlineEdit = ({ action, data }) => {
+        switch (action) {
+            case 'validate':
+                appState.renameEditingFile(cache, data)
+                break
+
+            case 'start':
+                console.log('starting edit file')
+                const file = data.nodeData
+                cache.setEditingFile(file)
+                break
+
+                cancel: cache.setEditingFile(null)
         }
     }
 
@@ -253,13 +269,7 @@ const FileView = observer(({ hide }: Props) => {
                             onItemDoubleClick={onItemDoubleClick}
                             onHeaderClick={onHeaderClick}
                             onBlankAreaClick={onBlankAreaClick}
-                            onInlineEdit={({ action, data }) => {
-                                if (action === 'validate') {
-                                    appState.renameEditingFile(cache, data)
-                                } else {
-                                    cache.setEditingFile(null)
-                                }
-                            }}
+                            onInlineEdit={onInlineEdit}
                             onItemRightClick={({ index, event }) => {
                                 rightClickFileIndexRef.current = index
                                 ctxMenuProps.onContextMenu(event)

--- a/src/components/layouts/Table/components/Column/Name.tsx
+++ b/src/components/layouts/Table/components/Column/Name.tsx
@@ -4,6 +4,7 @@ import { Icon, InputGroup } from '@blueprintjs/core'
 import type { FileViewItem } from '$src/types'
 import { InlineEditEvent } from '$src/hooks/useLayout'
 import { getSelectionRange } from '$src/utils/fileUtils'
+import { CLICK_DELAY } from '../Row'
 
 interface Props {
     data: FileViewItem
@@ -11,8 +12,9 @@ interface Props {
 }
 
 export const Name = ({ data, onInlineEdit }: Props) => {
-    const { icon, title, isEditing, name } = data
+    const { icon, title, isEditing, isSelected, name } = data
     const inputRef = useRef<HTMLInputElement>()
+    const clickRef: React.MutableRefObject<number> = useRef(-CLICK_DELAY)
 
     useEffect(() => {
         if (isEditing) {
@@ -31,7 +33,24 @@ export const Name = ({ data, onInlineEdit }: Props) => {
         <div className="name">
             <Icon icon={icon}></Icon>
             {!isEditing ? (
-                <span title={title} className="file-label" data-cy-filename>
+                <span
+                    title={title}
+                    onClick={(e: React.MouseEvent<HTMLElement>) => {
+                        if (isSelected && e.timeStamp - clickRef.current > CLICK_DELAY) {
+                            console.log('first click & selected: enable online')
+                            e.stopPropagation()
+                            onInlineEdit({
+                                event,
+                                action: 'start',
+                            })
+                        } else if (isSelected) {
+                            console.log('isSelected but delay too small: double click ?')
+                        }
+                        clickRef.current = e.timeStamp
+                    }}
+                    className="file-label"
+                    data-cy-filename
+                >
                     {data.name}
                 </span>
             ) : (

--- a/src/components/layouts/Table/components/Row/__tests__/index.test.tsx
+++ b/src/components/layouts/Table/components/Row/__tests__/index.test.tsx
@@ -80,15 +80,6 @@ describe('Row', () => {
             expect(PROPS.onRowDoubleClick).not.toHaveBeenCalled()
         })
 
-        it('should not call click handler if file is already selected and the user clicks on the size column', async () => {
-            item.isSelected = true
-
-            const { user } = setup(<Row {...PROPS} />)
-            await user.click(screen.getByText(item.size))
-
-            expect(PROPS.onRowClick).not.toHaveBeenCalled()
-        })
-
         // it.only('should show drag overlay when user drags the row', async () => {
         //     const { user } = setup(<Row {...PROPS} />)
 

--- a/src/components/layouts/Table/components/Row/index.tsx
+++ b/src/components/layouts/Table/components/Row/index.tsx
@@ -62,12 +62,7 @@ export const Row = ({
                     e.stopPropagation()
 
                     if (e.timeStamp - clickRef.current > CLICK_DELAY) {
-                        // If the row is already selected, calling the event handler
-                        // will enable inline edit: we only want that to happen if the user
-                        // clicks on the filename only, not on the icon or size.
-                        if (!rowData.isSelected) {
-                            clickHandler(e)
-                        }
+                        clickHandler(e)
                     } else {
                         doubleClickHandler(e)
                     }

--- a/src/components/layouts/Table/components/Row/index.tsx
+++ b/src/components/layouts/Table/components/Row/index.tsx
@@ -65,7 +65,7 @@ export const Row = ({
                         // If the row is already selected, calling the event handler
                         // will enable inline edit: we only want that to happen if the user
                         // clicks on the filename only, not on the icon or size.
-                        if (!rowData.isSelected || (e.target as HTMLElement).classList.contains('file-label')) {
+                        if (!rowData.isSelected) {
                             clickHandler(e)
                         }
                     } else {

--- a/src/css/fileview-table.css
+++ b/src/css/fileview-table.css
@@ -41,6 +41,7 @@
 
 .tableRow .name {
     display:flex;
+    height: 100%;
     align-items: center;
     margin-left: 10px;
     flex-grow: 1;
@@ -48,7 +49,10 @@
 }
 
 .tableRow .file-label {
+    display: flex;
     flex-grow:1;
+    height: 100%;
+    align-items: center;
     overflow:hidden;
     white-space: pre;
     text-overflow:ellipsis;

--- a/src/hooks/useLayout.tsx
+++ b/src/hooks/useLayout.tsx
@@ -24,7 +24,7 @@ export interface HeaderMouseEvent {
 }
 
 export interface InlineEditEvent {
-    data?: string
+    data?: string | FileViewItem
     action: 'cancel' | 'validate' | 'start'
     event: React.SyntheticEvent
 }

--- a/src/hooks/useLayout.tsx
+++ b/src/hooks/useLayout.tsx
@@ -25,7 +25,7 @@ export interface HeaderMouseEvent {
 
 export interface InlineEditEvent {
     data?: string
-    action: 'cancel' | 'validate'
+    action: 'cancel' | 'validate' | 'start'
     event: React.SyntheticEvent
 }
 


### PR DESCRIPTION
Also made the name element take the whole line height so that clicking just below the text enables inline-edit.