### PR TITLE
TableLayout/Name: do not enable inline edit when 2+ rows are selected

### DIFF
--- a/src/components/FileView.tsx
+++ b/src/components/FileView.tsx
@@ -159,7 +159,6 @@ const FileView = observer(({ hide }: Props) => {
                 break
 
             case 'start':
-                console.log('starting edit file')
                 const file = (data as FileViewItem).nodeData
                 cache.setEditingFile(file)
                 break

--- a/src/components/layouts/Table/__tests__/index.test.tsx
+++ b/src/components/layouts/Table/__tests__/index.test.tsx
@@ -6,7 +6,7 @@ import * as ReactVirtual from 'react-virtual'
 import { render, screen, setup, t } from 'rtl'
 
 import { Column } from '$src/hooks/useLayout'
-import { TStatus } from '$src/state/fileState'
+import { FileState, TStatus } from '$src/state/fileState'
 import { FileViewItem } from '$src/types'
 
 import { TableLayout } from '..'
@@ -58,7 +58,11 @@ describe('TableLayout', () => {
         onInlineEdit: jest.fn(),
         onHeaderClick: jest.fn(),
         getDragProps: jest.fn(() => ({
-            fileState: null,
+            fileState: {
+                selected: {
+                    length: 0,
+                },
+            } as FileState,
             dragFiles: new Array(2),
         })),
         getItem: jest.fn((index) => items[index]),

--- a/src/components/layouts/Table/components/Column/Name.tsx
+++ b/src/components/layouts/Table/components/Column/Name.tsx
@@ -10,9 +10,10 @@ import { isMac } from '$src/utils/platform'
 interface Props {
     data: FileViewItem
     onInlineEdit?: (event: InlineEditEvent) => void
+    selectedCount: number
 }
 
-export const Name = ({ data, onInlineEdit }: Props) => {
+export const Name = ({ data, onInlineEdit, selectedCount }: Props) => {
     const { icon, title, isEditing, isSelected, name } = data
     const inputRef = useRef<HTMLInputElement>()
     const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
@@ -43,7 +44,12 @@ export const Name = ({ data, onInlineEdit }: Props) => {
                 <span
                     title={title}
                     onClick={(e: React.MouseEvent<HTMLElement>) => {
-                        if (!timeoutRef.current && !e.shiftKey && !(isMac ? e.metaKey : e.ctrlKey)) {
+                        if (
+                            !timeoutRef.current &&
+                            selectedCount < 2 &&
+                            !e.shiftKey &&
+                            !(isMac ? e.metaKey : e.ctrlKey)
+                        ) {
                             e.persist()
                             timeoutRef.current = setTimeout(() => {
                                 timeoutRef.current = undefined

--- a/src/components/layouts/Table/components/Column/__tests__/Name.test.tsx
+++ b/src/components/layouts/Table/components/Column/__tests__/Name.test.tsx
@@ -3,6 +3,7 @@
  */
 import { FileViewItem } from '$src/types'
 import React from 'react'
+import userEvent from '@testing-library/user-event'
 import { render, screen, setup } from 'rtl'
 
 import { Name } from '../Name'
@@ -11,6 +12,7 @@ describe('Name', () => {
     const item = {
         icon: 'add',
         isEditing: false,
+        isSelected: false,
         name: 'filename',
         title: 'title',
     } as FileViewItem
@@ -18,6 +20,7 @@ describe('Name', () => {
     const PROPS = {
         data: item,
         onInlineEdit: jest.fn(),
+        selectedCount: 0,
     }
 
     beforeEach(() => jest.clearAllMocks())
@@ -32,6 +35,52 @@ describe('Name', () => {
         expect(container.querySelector(`[icon="${item.icon}"]`)).toBeInTheDocument()
     })
 
+    describe('start edit mode', () => {
+        const editItem = {
+            ...item,
+            isSelected: true,
+        }
+
+        beforeEach(() => jest.useFakeTimers())
+        afterEach(() => jest.useRealTimers())
+
+        it('should start edit mode when clicking on name', async () => {
+            const PROPS = {
+                data: editItem,
+                onInlineEdit: jest.fn(),
+                selectedCount: 0,
+            }
+
+            const user = userEvent.setup({ advanceTimers: jest.runOnlyPendingTimers })
+
+            render(<Name {...PROPS} />)
+
+            await user.click(screen.getByText(item.name))
+
+            expect(PROPS.onInlineEdit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'start',
+                }),
+            )
+        })
+
+        it('should not start edit mode when clicking on name and several files are selected', async () => {
+            const PROPS = {
+                data: editItem,
+                onInlineEdit: jest.fn(),
+                selectedCount: 2,
+            }
+
+            const user = userEvent.setup({ advanceTimers: jest.runOnlyPendingTimers })
+
+            render(<Name {...PROPS} />)
+
+            await user.click(screen.getByText(item.name))
+
+            expect(PROPS.onInlineEdit).not.toHaveBeenCalled()
+        })
+    })
+
     describe('edit mode', () => {
         const editItem = {
             ...item,
@@ -41,6 +90,7 @@ describe('Name', () => {
         const PROPS = {
             data: editItem,
             onInlineEdit: jest.fn(),
+            selectedCount: 0,
         }
 
         it('should show edit input', () => {

--- a/src/components/layouts/Table/components/Row/__tests__/index.test.tsx
+++ b/src/components/layouts/Table/components/Row/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { FileState } from '$src/state/fileState'
 import { FileViewItem } from '$src/types'
 import React from 'react'
 import { render, screen, setup, userEvent, wait } from 'rtl'
@@ -24,7 +25,11 @@ describe('Row', () => {
         onRowRightClick: jest.fn(),
         onInlineEdit: jest.fn(),
         getDragProps: jest.fn(() => ({
-            fileState: null,
+            fileState: {
+                selected: {
+                    length: 0,
+                },
+            } as FileState,
             dragFiles: new Array(2),
         })),
         isDarkModeActive: false,

--- a/src/components/layouts/Table/components/Row/index.tsx
+++ b/src/components/layouts/Table/components/Row/index.tsx
@@ -74,7 +74,7 @@ export const Row = ({
                 }}
                 style={{ width: '100%', height: '100%', alignItems: 'center', display: 'flex' }}
             >
-                <Name data={rowData} onInlineEdit={onInlineEdit} />
+                <Name data={rowData} onInlineEdit={onInlineEdit} selectedCount={dragProps.fileState.selected.length} />
                 <Size data={rowData} />
             </div>
         </>


### PR DESCRIPTION
Note that we are getting the selected length from the draggedProps: this should be improved as these are two unrelated things.