### PR TITLE
Fs: use bigint version of file stats, fixes #366 #365

### DIFF
--- a/src/services/Fs.ts
+++ b/src/services/Fs.ts
@@ -16,8 +16,8 @@ export function registerFs(fs: Fs): void {
 }
 
 export interface FileID {
-    ino: number
-    dev: number
+    ino: bigint
+    dev: bigint
 }
 
 export interface FileDescriptor {
@@ -71,7 +71,7 @@ export const ExeMaskUser = 0o0100
 
 export type FileType = 'exe' | 'img' | 'arc' | 'snd' | 'vid' | 'doc' | 'cod' | ''
 
-export function MakeId(stats: { ino: number; dev: number }): FileID {
+export function MakeId(stats: { ino: bigint; dev: bigint }): FileID {
     return {
         ino: stats.ino,
         dev: stats.dev,

--- a/src/services/__tests__/Fs.test.ts
+++ b/src/services/__tests__/Fs.test.ts
@@ -5,8 +5,8 @@ import { MakeId, ExeMaskAll, ExeMaskGroup, ExeMaskUser, filetype, sameID, FileID
 describe('makeId', () => {
     it('should return FileID from stats', () => {
         const stats = {
-            ino: 123,
-            dev: 456,
+            ino: 123n,
+            dev: 456n,
             fullname: 'foo',
         }
 
@@ -19,13 +19,13 @@ describe('makeId', () => {
 
 describe('sameID', () => {
     const id1: FileID = {
-        dev: 10,
-        ino: 5,
+        dev: 10n,
+        ino: 5n,
     }
 
     const id2: FileID = {
-        dev: 28,
-        ino: 32,
+        dev: 28n,
+        ino: 32n,
     }
 
     it('should return true if ino & dev are identical', () => {

--- a/src/services/__tests__/FsSort.test.ts
+++ b/src/services/__tests__/FsSort.test.ts
@@ -15,8 +15,8 @@ const files: Array<FileDescriptor> = [
         isDir: true,
         readonly: false,
         id: {
-            ino: 0,
-            dev: 1,
+            ino: 0n,
+            dev: 1n,
         },
         isSym: false,
         target: '',
@@ -35,8 +35,8 @@ const files: Array<FileDescriptor> = [
         isDir: false,
         readonly: false,
         id: {
-            ino: 1,
-            dev: 1,
+            ino: 1n,
+            dev: 1n,
         },
         isSym: false,
         target: '',
@@ -55,8 +55,8 @@ const files: Array<FileDescriptor> = [
         isDir: false,
         readonly: false,
         id: {
-            ino: 2,
-            dev: 1,
+            ino: 2n,
+            dev: 1n,
         },
         isSym: false,
         target: '',
@@ -75,8 +75,8 @@ const files: Array<FileDescriptor> = [
         isDir: false,
         readonly: false,
         id: {
-            ino: 3,
-            dev: 1,
+            ino: 3n,
+            dev: 1n,
         },
         isSym: false,
         target: '',
@@ -88,24 +88,24 @@ describe('sorting methods', () => {
     it('sort by Name/Asc', () => {
         const sortMethod = getSortMethod('name', 'asc')
         const sorted_ids = files.sort(sortMethod).map((file) => file.id.ino)
-        expect(sorted_ids).toEqual([2, 0, 1, 3])
+        expect(sorted_ids).toEqual([2n, 0n, 1n, 3n])
     })
 
     it('sort by Name/Desc', () => {
         const sortMethod = getSortMethod('name', 'desc')
         const sorted_ids = files.sort(sortMethod).map((file) => file.id.ino)
-        expect(sorted_ids).toEqual([3, 1, 0, 2])
+        expect(sorted_ids).toEqual([3n, 1n, 0n, 2n])
     })
 
     it('sort by Size/Asc', () => {
         const sortMethod = getSortMethod('size', 'asc')
         const sorted_ids = files.sort(sortMethod).map((file) => file.id.ino)
-        expect(sorted_ids).toEqual([1, 0, 3, 2])
+        expect(sorted_ids).toEqual([1n, 0n, 3n, 2n])
     })
 
     it('sort by Size/Asc', () => {
         const sortMethod = getSortMethod('size', 'desc')
         const sorted_ids = files.sort(sortMethod).map((file) => file.id.ino)
-        expect(sorted_ids).toEqual([2, 3, 0, 1])
+        expect(sorted_ids).toEqual([2n, 3n, 0n, 1n])
     })
 })

--- a/src/services/plugins/FsFtp.ts
+++ b/src/services/plugins/FsFtp.ts
@@ -231,8 +231,8 @@ class Client {
                                 isSym: false,
                                 target: null,
                                 id: {
-                                    ino: mDate.getTime(),
-                                    dev: new Date().getTime(),
+                                    ino: BigInt(mDate.getTime()),
+                                    dev: BigInt(new Date().getTime()),
                                 },
                             }
                             return file


### PR DESCRIPTION
Note: only the `ino` & `dev` are used as `bigint`, other numeric inputs are converted to `number` so there may be other limitations (`length` for eg.). But changing `length` to `bigint` would require lots more work so this should be done in another PR.