### PR TITLE
StatusBar: move hidden files toggle to the left

### DIFF
--- a/src/components/Statusbar.tsx
+++ b/src/components/Statusbar.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { InputGroup, ControlGroup, Button, Intent } from '@blueprintjs/core'
+import { Button, Intent } from '@blueprintjs/core'
 import { IconNames } from '@blueprintjs/icons'
 import { Tooltip2 } from '@blueprintjs/popover2'
 import { observer } from 'mobx-react'
@@ -43,18 +43,12 @@ const Statusbar = observer(() => {
     )
 
     return (
-        <ControlGroup>
-            <InputGroup
-                disabled
-                rightElement={
-                    <ToggleHiddenFilesButton showHiddenFiles={showHiddenFiles} content={content} onClick={onClick} />
-                }
-                value={`${t('STATUS.FILES', { count: numFiles })}, ${t('STATUS.FOLDERS', {
-                    count: numDirs,
-                })}`}
-                className="status-bar"
-            />
-        </ControlGroup>
+        <div className="status-bar">
+            <ToggleHiddenFilesButton showHiddenFiles={showHiddenFiles} content={content} onClick={onClick} />
+            {`${t('STATUS.FILES', { count: numFiles })}, ${t('STATUS.FOLDERS', {
+                count: numDirs,
+            })}`}
+        </div>
     )
 })
 

--- a/src/components/__tests__/SideView.test.tsx
+++ b/src/components/__tests__/SideView.test.tsx
@@ -63,7 +63,7 @@ describe('SideView', () => {
         }
 
         // status bar
-        expect(screen.getByDisplayValue(buildStatusBarText())).toBeInTheDocument()
+        expect(screen.getByText(buildStatusBarText())).toBeInTheDocument()
 
         // overlay d&d
         expect(screen.getByTestId('drop-overlay-0')).toBeInTheDocument()

--- a/src/components/__tests__/Statusbar.test.tsx
+++ b/src/components/__tests__/Statusbar.test.tsx
@@ -35,7 +35,7 @@ describe('Statusbar', () => {
     it('should display statusbar text and toggle hidden files button', () => {
         render(<Statusbar />, options)
 
-        expect(screen.getByRole('textbox')).toHaveValue(buildStatusBarText())
+        expect(screen.getByText(buildStatusBarText())).toBeInTheDocument()
         expect(screen.getByRole('button')).toBeInTheDocument()
     })
 
@@ -44,7 +44,7 @@ describe('Statusbar', () => {
 
         await user.click(screen.getByRole('button'))
 
-        expect(screen.getByRole('textbox')).toHaveValue(buildStatusBarText())
+        expect(screen.getByText(buildStatusBarText())).toBeInTheDocument()
     })
 
     it('toggle hidden files button should be inactive if cache is not ready', async () => {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -359,32 +359,15 @@ body.bp4-dark .app-loader.active{
 }
 
 .status-bar {
+    background: rgba(206, 217, 224, 0.5);
     border-top: 1px solid rgb(189, 195, 199);
-}
-
-/* FIXME: we only used disable state to use the styles associated with disabled state */
-.status-bar .bp4-input:disabled,
-.status-bar .bp4-input.bp4-disabled,
-.status-bar .bp4-button.bp4-disabled,
-.status-bar button.bp4-minimal.bp4-disabled,
-.status-bar button.bp4-minimal.bp4-disabled:hover,
-.status-bar.bp4-input-group.bp4-disabled {
-    cursor:default;
+    padding-top: 4px;
+    padding-bottom: 4px;
 }
 
 .bp4-dark .status-bar {
+    background-color:rgb(41, 56, 66);
     border-top: 1px solid rgb(14,25,34);
-}
-
-.status-bar.offline > .bp4-icon:after{
-    border-bottom: 1px solid rgba(255,0,0,.6);
-    content: "";
-    width: 100%;
-    height: 50%;
-    position: absolute;
-    top: 2px;
-    transform: rotateZ(-45deg);
-    left: -2px;
 }
 
 .tablist{


### PR DESCRIPTION
Resizing the app's window could make the user accidentally click on the toggle button.