### PR TITLE
SettingsState: put lang change into runInAction()

### DIFF
--- a/src/state/settingsState.ts
+++ b/src/state/settingsState.ts
@@ -95,7 +95,7 @@ export class SettingsState {
         // finally set requested language
         i18next.changeLanguage(lang)
 
-        this.lang = i18next.language
+        runInAction(() => (this.lang = i18next.language))
     }
 
     setDefaultTerminal(cmd: string): void {


### PR DESCRIPTION
This prevents a warning from MobX since state cannot be modified out of an action. Not sure why this happens since setLanguage is already set as action: I guess it has something to do with the fact that it's an async function.