### PR TITLE
Menus: disable non-available entries

### DIFF
--- a/e2e/cypress/e2e/tablist.spec.ts
+++ b/e2e/cypress/e2e/tablist.spec.ts
@@ -77,20 +77,24 @@ describe('tablist', () => {
 
         cy.get('#view_0 .tablist').contains('/').find('[icon]').rightclick()
 
-        cy.get('@stub_invoke').should('be.calledOnce').and('be.calledWith', 'Menu:buildFromTemplate')
-
-        // cy.get('@stub_popup').should('be.calledOnce')
+        cy.get('@stub_invoke')
+            .should('be.called')
+            .then((stub: any) => {
+                // check we have the correct number of elements in the menu template
+                // NOTE: I guess we can do a lot better than that!
+                expect(stub.getCalls()[1].args[0]).to.equal('Menu:buildFromTemplate')
+            })
     })
 
     it('right-click on the tab should show the tab menu', () => {
         cy.get('#view_0 .tablist').contains('/').find('.bp4-button-text').rightclick('right')
 
         cy.get('@stub_invoke')
-            .should('be.calledOnce')
+            .should('be.called')
             .then((stub: any) => {
                 // check we have the correct number of elements in the menu template
                 // NOTE: I guess we can do a lot better than that!
-                expect(stub.getCalls()[0].args[1].length).to.equal(8)
+                expect(stub.getCalls()[1].args[1].length).to.equal(8)
             })
     })
 

--- a/src/components/menus/FileContextMenu.tsx
+++ b/src/components/menus/FileContextMenu.tsx
@@ -15,6 +15,7 @@ const FileContextMenu = ({ fileUnderMouse }: Props) => {
     const clipboard = appState.clipboard
     const cache = appState.getActiveCache()
 
+    // TODO: disable delete/paste when cahce.fs.readonly is true
     const numFilesInClipboard = clipboard.files.length
     const isInSelection = fileUnderMouse && !!cache.selected.find((file) => sameID(file.id, fileUnderMouse.id))
     const isPasteEnabled = numFilesInClipboard && ((!fileUnderMouse && !cache.error) || fileUnderMouse?.isDir)

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -7,6 +7,7 @@ import { AppMenu, LocaleString } from '$src/electron/appMenus'
 import { isLinux } from '$src/electron/osSupport'
 import { WindowSettings } from '$src/electron//windowSettings'
 import { Remote } from '$src/electron/remote'
+import { ReactiveProperties } from '$src/types'
 
 const ENV_E2E = !!process.env.E2E
 const HTML_PATH = `${__dirname}/index.html`
@@ -155,7 +156,7 @@ const ElectronApp = {
      * - reloadIgnoringCache: need to reload the main window (dev only)
      * - exit: wants to exit the app
      * - openTerminal(cmd): should open a new terminal process using specified cmd line
-     * - languageChanged(strings): language has been changed so menus need to be updated
+     * - updateMenus(strings): language has been changed so menus need to be updated
      * - selectAll: wants to generate a selectAll event
      */
     installIpcMainListeners() {
@@ -186,9 +187,10 @@ const ElectronApp = {
             })
         })
 
-        ipcMain.handle('languageChanged', (e: Event, strings: LocaleString, lang: string) => {
+        ipcMain.handle('updateMenus', (e: Event, strings: LocaleString, props: ReactiveProperties) => {
+            console.log('** need to update menus :)')
             if (this.appMenu) {
-                this.appMenu.createMenu(strings, lang)
+                this.appMenu.createMenu(strings, props)
             } else {
                 console.log('languageChanged but app not ready :(')
             }

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -1,6 +1,5 @@
 import i18next from 'i18next'
 import type { Resource } from 'i18next'
-import { ipcRenderer } from 'electron'
 
 const locales: Resource = {}
 
@@ -36,10 +35,6 @@ const i18n = {
     }),
     i18next,
 }
-
-i18next.on('languageChanged', (lang: string): void => {
-    ipcRenderer.invoke('languageChanged', i18next.t('APP_MENUS', { returnObjects: true }), lang)
-})
 
 const languageList = Object.keys(locales)
 

--- a/src/state/appState.tsx
+++ b/src/state/appState.tsx
@@ -417,9 +417,13 @@ export class AppState {
         }
     }
 
-    getActiveCache(): FileState {
+    getActiveView(): ViewState {
         const winState = this.winStates[0]
-        const view = winState.getActiveView()
+        return winState.getActiveView()
+    }
+
+    getActiveCache(): FileState {
+        const view = this.getActiveView()
         return this.isExplorer ? view.caches.find((cache) => cache.isVisible === true) : null
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import { FileDescriptor } from '$src/services/Fs'
-import { FileState } from '$src/state/fileState'
+import { FileState, TStatus } from '$src/state/fileState'
 import { IconName } from '@blueprintjs/icons'
 import { IpcRendererEvent } from 'electron/renderer'
 
@@ -31,3 +31,16 @@ export interface DraggedObject {
 }
 
 export type ArrowKey = 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight'
+
+// Properties that trigger an update of native menus
+export interface ReactiveProperties {
+    activeViewTabNums: number
+    isReadonly: boolean
+    isIndirect: boolean
+    isOverlayOpen: boolean
+    isExplorer: boolean
+    path: string
+    selectedLength: number
+    status: TStatus
+    language: string
+}


### PR DESCRIPTION
Also:

- added a mobx reaction to regenerate menus when needed
- clean up menus init: will be called on reaction

Fixes #401 