### PR TITLE
TableView/Header: stop contextMenu propagation

### DIFF
--- a/src/components/viewmodes/TableViewMode/components/Header/index.tsx
+++ b/src/components/viewmodes/TableViewMode/components/Header/index.tsx
@@ -25,7 +25,11 @@ export const SortIndicator = ({ sort }: { sort: TSORT_ORDER | 'none' }) => {
 
 export const Header = ({ onClick, columns, height }: HeaderProps) => {
     return (
-        <div className="tableHeader headerRow" style={{ height: `${height}px` }}>
+        <div
+            className="tableHeader headerRow"
+            style={{ height: `${height}px` }}
+            onContextMenu={(e) => e.stopPropagation()}
+        >
             {columns.map(({ label, key, sort }, i) => {
                 return (
                     <div


### PR DESCRIPTION
This prevents the file context menu from opening when clicking on the header.

We'll probably have a context menu for changing sort method/order in the future.

Fixes #415 