### PR TITLE
Toolbar: set input size to "1"

### DIFF
--- a/src/components/SideView.tsx
+++ b/src/components/SideView.tsx
@@ -68,7 +68,7 @@ export const SideView = observer(({ hide, viewState }: SideViewProps) => {
         <Provider viewState={viewState}>
             <div ref={drop} id={divId} className={activeClass}>
                 {needLogin && <LoginDialog isOpen={needLogin} onValidation={onValidation} onClose={onClose} />}
-                <TabList></TabList>
+                <TabList />
                 <Toolbar active={!busy} />
                 <FileView hide={hide} />
                 <Statusbar />

--- a/src/components/Toolbar/index.tsx
+++ b/src/components/Toolbar/index.tsx
@@ -243,6 +243,9 @@ export const Toolbar = observer(({ active }: Props) => {
                     onBlur={onBlur}
                     onFocus={onFocus}
                     disabled={!active}
+                    // allows input shrinking to a very low width:
+                    // without it, it would refuse shrinking below 100px
+                    size={1}
                 />
                 {isMakedirDialogOpen && (
                     <MakedirDialog


### PR DESCRIPTION
On a text input, the size sets the min width of the element so we set it to the minimum value so that the input can shrink a lot more.

Note that this only mitigates the problem: because of the right padding of 30px, there is still a little bit of overflow when the window is tiny.

Fixes #370 