### PR TITLE
IconView: fixed getNextIndex calculation

### DIFF
--- a/src/components/viewmodes/IconViewMode/index.tsx
+++ b/src/components/viewmodes/IconViewMode/index.tsx
@@ -107,7 +107,7 @@ export const IconViewMode = forwardRef<ViewModeActions, ViewModeProps<IconViewMo
                 },
                 icons: true,
             }),
-            [itemsPerRow],
+            [itemsPerRow, numRows],
         )
 
         useEffect(() => {


### PR DESCRIPTION
NumRows was missing from the list of useImperativeHandle keyboard navigation was broken when changing directory if it had more/less rows.