### PR TITLE
FileView: fixed open file shortcut on Linux/Win

### DIFF
--- a/src/components/FileView.tsx
+++ b/src/components/FileView.tsx
@@ -251,7 +251,7 @@ const FileView = observer(({ hide }: Props) => {
 
     const onOpenFile = (e: KeyboardEvent): void => {
         if (isViewActive && cursor) {
-            openFileOrDirectory(cursor, isMac ? e.altKey : e.ctrlKey)
+            openFileOrDirectory(cursor, isMac ? e.altKey : e.shiftKey)
         }
     }
 


### PR DESCRIPTION
Pressing `ctrl+o` would incorrectly open in another view where it should open in current view.

Fixes #431 