### PR TITLE
PreviewDialog: don't refresh preview unless file uri has changed

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -304,7 +304,7 @@ const App = observer(() => {
                     {splitView && <SideView viewState={views[1]} hide={!isExplorer} />}
                     <Downloads hide={isExplorer} />
                 </div>
-                <PreviewDialog />
+                {cache.cursor && <PreviewDialog />}
             </React.Fragment>
         </Provider>
     )


### PR DESCRIPTION
This fixes a glitch that appeared on Windows where FS changes everytime a file is accessed.

Problem also appeared on Unix if the folder was updated.

This commit also fixes the NoPreview date/size that wasn't always updated.